### PR TITLE
feat(scope-hooks): enable plugins to inject parameters directly into test callbacks

### DIFF
--- a/src/@types/plugin.ts
+++ b/src/@types/plugin.ts
@@ -97,15 +97,22 @@ export type InspectCLIResult = {
 
 export type ScopeHookHolder = { scope: unknown };
 
+export type ScopeHookParams = Record<string, unknown>;
+
 export type ScopeHooks = {
   createHolder: () => ScopeHookHolder;
   runScoped: (
     holder: ScopeHookHolder,
-    fn: () => Promise<unknown> | unknown
+    fn: (params?: ScopeHookParams) => Promise<unknown> | unknown
   ) => Promise<void>;
 };
 
-export type ScopeHookProvider = ScopeHooks & {
+export type ScopeHookProvider = {
   /** Stable provider id for deterministic dedupe/composition. */
   name: string;
+  createHolder: () => ScopeHookHolder;
+  runScoped: (
+    holder: ScopeHookHolder,
+    fn: (params?: ScopeHookParams) => Promise<unknown> | unknown
+  ) => Promise<void>;
 };

--- a/src/modules/helpers/it/core.ts
+++ b/src/modules/helpers/it/core.ts
@@ -1,3 +1,4 @@
+import type { ScopeHookParams } from '../../../@types/plugin.js';
 import { AssertionError } from 'node:assert';
 import process from 'node:process';
 import { each } from '../../../configs/each.js';
@@ -12,14 +13,22 @@ export const getTitle = (input: unknown): string | undefined =>
 
 export const getCallback = (
   input: unknown
-): (() => unknown) | (() => Promise<unknown>) | undefined =>
+):
+  | ((params?: ScopeHookParams) => unknown)
+  | ((params?: ScopeHookParams) => Promise<unknown>)
+  | undefined =>
   typeof input === 'function'
-    ? (input as (() => unknown) | (() => Promise<unknown>))
+    ? (input as
+        | ((params?: ScopeHookParams) => unknown)
+        | ((params?: ScopeHookParams) => Promise<unknown>))
     : undefined;
 
+const normalizeContext = (params?: ScopeHookParams): ScopeHookParams =>
+  params ?? {};
+
 export const itBase = async (
-  titleOrCb: string | (() => unknown | Promise<unknown>),
-  callback?: () => unknown | Promise<unknown>
+  titleOrCb: string | ((params: ScopeHookParams) => unknown | Promise<unknown>),
+  callback?: (params: ScopeHookParams) => unknown | Promise<unknown>
 ): Promise<void> => {
   try {
     const title = getTitle(titleOrCb);
@@ -61,9 +70,11 @@ export const itBase = async (
       const hooks = getScopeHooks();
       if (hooks) {
         const holder = hooks.createHolder();
-        await hooks.runScoped(holder, () => cb!());
+        await hooks.runScoped(holder, (params) =>
+          cb!(normalizeContext(params))
+        );
       } else {
-        const resultCb = cb!();
+        const resultCb = cb!(normalizeContext());
         if (resultCb instanceof Promise) await resultCb;
       }
     } catch (error) {
@@ -107,13 +118,23 @@ export const itBase = async (
   }
 };
 
-async function itCore(title: string, cb: () => Promise<unknown>): Promise<void>;
-function itCore(title: string, cb: () => unknown): void;
-async function itCore(cb: () => Promise<unknown>): Promise<void>;
-function itCore(cb: () => unknown): void;
 async function itCore(
-  titleOrCb: string | (() => unknown) | (() => Promise<unknown>),
-  cb?: (() => unknown) | (() => Promise<unknown>)
+  title: string,
+  cb: (params: ScopeHookParams) => Promise<unknown>
+): Promise<void>;
+function itCore(title: string, cb: (params: ScopeHookParams) => unknown): void;
+async function itCore(
+  cb: (params: ScopeHookParams) => Promise<unknown>
+): Promise<void>;
+function itCore(cb: (params: ScopeHookParams) => unknown): void;
+async function itCore(
+  titleOrCb:
+    | string
+    | ((params: ScopeHookParams) => unknown)
+    | ((params: ScopeHookParams) => Promise<unknown>),
+  cb?:
+    | ((params: ScopeHookParams) => unknown)
+    | ((params: ScopeHookParams) => Promise<unknown>)
 ): Promise<void> {
   if (GLOBAL.configs.testNamePattern && typeof titleOrCb === 'string') {
     if (!GLOBAL.configs.testNamePattern.test(titleOrCb)) return;

--- a/src/modules/plugins.ts
+++ b/src/modules/plugins.ts
@@ -1,6 +1,6 @@
+import type { Buffer } from 'node:buffer';
 import type { SpawnOptionsWithoutStdio } from 'node:child_process';
 import type { InspectCLIResult, PokuPlugin } from '../@types/plugin.js';
-import type { Buffer } from 'node:buffer';
 import { spawn } from 'node:child_process';
 import { env } from 'node:process';
 import { kill as pokuKill } from '../modules/helpers/kill.js';

--- a/src/modules/plugins.ts
+++ b/src/modules/plugins.ts
@@ -1,6 +1,6 @@
 import type { SpawnOptionsWithoutStdio } from 'node:child_process';
 import type { InspectCLIResult, PokuPlugin } from '../@types/plugin.js';
-import { Buffer } from 'node:buffer';
+import type { Buffer } from 'node:buffer';
 import { spawn } from 'node:child_process';
 import { env } from 'node:process';
 import { kill as pokuKill } from '../modules/helpers/kill.js';

--- a/src/modules/plugins.ts
+++ b/src/modules/plugins.ts
@@ -1,5 +1,6 @@
 import type { SpawnOptionsWithoutStdio } from 'node:child_process';
 import type { InspectCLIResult, PokuPlugin } from '../@types/plugin.js';
+import { Buffer } from 'node:buffer';
 import { spawn } from 'node:child_process';
 import { env } from 'node:process';
 import { kill as pokuKill } from '../modules/helpers/kill.js';
@@ -18,6 +19,7 @@ export type {
   PluginContext,
   InspectCLIResult,
   ScopeHookHolder,
+  ScopeHookParams,
   ScopeHookProvider,
   ScopeHooks,
 } from '../@types/plugin.js';

--- a/src/modules/plugins/scope-hooks.ts
+++ b/src/modules/plugins/scope-hooks.ts
@@ -1,5 +1,6 @@
 import type {
   ScopeHookHolder,
+  ScopeHookParams,
   ScopeHookProvider,
   ScopeHooks,
 } from '../../@types/plugin.js';
@@ -46,6 +47,14 @@ const normalizeProviders = (
   ];
 };
 
+const mergeScopeParams = (
+  base: ScopeHookParams,
+  incoming?: ScopeHookParams
+): ScopeHookParams => {
+  if (!incoming) return base;
+  return { ...base, ...incoming };
+};
+
 const createComposedHooks = (
   providers: ScopeHookProvider[]
 ): ScopeHooksWithProviders => {
@@ -69,9 +78,12 @@ const createComposedHooks = (
         composedHolder.__pokuProviders ??
         providers.map((provider) => provider.createHolder());
 
-      const invoke = async (index: number): Promise<void> => {
+      const invoke = async (
+        index: number,
+        params: ScopeHookParams
+      ): Promise<void> => {
         if (index >= providers.length) {
-          const result = fn();
+          const result = fn(params);
           if (result instanceof Promise) await result;
           return;
         }
@@ -83,10 +95,12 @@ const createComposedHooks = (
           throw new Error('Invalid scope hook composition state');
         }
 
-        await provider.runScoped(providerHolder, () => invoke(index + 1));
+        await provider.runScoped(providerHolder, (incomingParams) =>
+          invoke(index + 1, mergeScopeParams(params, incomingParams))
+        );
       };
 
-      await invoke(0);
+      await invoke(0, {});
     },
   };
 

--- a/test/__fixtures__/e2e/scope-hooks-params/params-injection.test.ts
+++ b/test/__fixtures__/e2e/scope-hooks-params/params-injection.test.ts
@@ -2,8 +2,8 @@ import { assert } from '../../../../src/modules/essentials/assert.js';
 import { describe } from '../../../../src/modules/helpers/describe.js';
 import { it } from '../../../../src/modules/helpers/it/core.js';
 import { test } from '../../../../src/modules/helpers/test.js';
-import { registerAlphaPlugin } from './plugins/alpha.plugin.ts';
-import { registerBetaPlugin } from './plugins/beta.plugin.ts';
+import { registerAlphaPlugin } from './plugins/alpha.plugin.js';
+import { registerBetaPlugin } from './plugins/beta.plugin.js';
 
 registerAlphaPlugin();
 registerBetaPlugin();

--- a/test/__fixtures__/e2e/scope-hooks-params/params-injection.test.ts
+++ b/test/__fixtures__/e2e/scope-hooks-params/params-injection.test.ts
@@ -1,0 +1,21 @@
+import { assert } from '../../../../src/modules/essentials/assert.js';
+import { describe } from '../../../../src/modules/helpers/describe.js';
+import { it } from '../../../../src/modules/helpers/it/core.js';
+import { test } from '../../../../src/modules/helpers/test.js';
+import { registerAlphaPlugin } from './plugins/alpha.plugin.ts';
+import { registerBetaPlugin } from './plugins/beta.plugin.ts';
+
+registerAlphaPlugin();
+registerBetaPlugin();
+
+describe('scope hooks fixture', () => {
+  it('injects params into it callback', ({ alpha, beta }) => {
+    assert.strictEqual(alpha, 'A', 'alpha param is injected');
+    assert.strictEqual(beta, 2, 'beta param is injected');
+  });
+
+  test('injects params into test callback', ({ alpha, beta }) => {
+    assert.strictEqual(alpha, 'A', 'alpha param reaches test alias');
+    assert.strictEqual(beta, 2, 'beta param reaches test alias');
+  });
+});

--- a/test/__fixtures__/e2e/scope-hooks-params/plugins/alpha.plugin.ts
+++ b/test/__fixtures__/e2e/scope-hooks-params/plugins/alpha.plugin.ts
@@ -1,0 +1,12 @@
+import { composeScopeHooks } from '../../../../../src/modules/plugins.js';
+
+export const registerAlphaPlugin = () => {
+  composeScopeHooks({
+    name: '@fixture/alpha-scope-plugin',
+    createHolder: () => ({ scope: undefined }),
+    runScoped: async (_holder, fn) => {
+      const result = fn({ alpha: 'A' });
+      if (result instanceof Promise) await result;
+    },
+  });
+};

--- a/test/__fixtures__/e2e/scope-hooks-params/plugins/beta.plugin.ts
+++ b/test/__fixtures__/e2e/scope-hooks-params/plugins/beta.plugin.ts
@@ -1,0 +1,12 @@
+import { composeScopeHooks } from '../../../../../src/modules/plugins.js';
+
+export const registerBetaPlugin = () => {
+  composeScopeHooks({
+    name: '@fixture/beta-scope-plugin',
+    createHolder: () => ({ scope: undefined }),
+    runScoped: async (_holder, fn) => {
+      const result = fn({ beta: 2 });
+      if (result instanceof Promise) await result;
+    },
+  });
+};

--- a/test/e2e/scope-hooks-params.test.ts
+++ b/test/e2e/scope-hooks-params.test.ts
@@ -1,0 +1,19 @@
+import { assert } from '../../src/modules/essentials/assert.js';
+import { poku } from '../../src/modules/essentials/poku.js';
+import { describe } from '../../src/modules/helpers/describe.js';
+import { it } from '../../src/modules/helpers/it/core.js';
+
+describe('Scope Hooks Params (e2e)', async () => {
+  await it('injects plugin params into userland it/test callbacks via poku()', async () => {
+    const code = await poku('./test/__fixtures__/e2e/scope-hooks-params', {
+      noExit: true,
+      quiet: true,
+    });
+
+    assert.strictEqual(
+      code,
+      0,
+      'Scope hook params should be injected and fixture should pass'
+    );
+  });
+});

--- a/test/unit/define-helpers.test.ts
+++ b/test/unit/define-helpers.test.ts
@@ -1,3 +1,4 @@
+import { afterEach } from '../../ci/src/services/each.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { test } from '../../src/modules/helpers/test.js';
 import { defineConfig } from '../../src/modules/index.js';
@@ -108,4 +109,45 @@ test('composeScopeHooks dedupes providers by name', () => {
     if (original === undefined) delete g[SCOPE_HOOKS_KEY];
     else g[SCOPE_HOOKS_KEY] = original;
   }
+});
+
+test('composeScopeHooks merges params from providers', async () => {
+  const SCOPE_HOOKS_KEY = Symbol.for('@pokujs/poku.test-scope-hooks');
+  const g = globalThis as Record<symbol, unknown>;
+  const original = g[SCOPE_HOOKS_KEY];
+
+  afterEach(() => {
+    if (original === undefined) delete g[SCOPE_HOOKS_KEY];
+    else g[SCOPE_HOOKS_KEY] = original;
+  });
+
+  delete g[SCOPE_HOOKS_KEY];
+
+  composeScopeHooks({
+    name: 'provider-alpha',
+    createHolder: () => ({ scope: undefined }),
+    runScoped: async (_holder, fn) => {
+      const result = fn({ alpha: 1 });
+      if (result instanceof Promise) await result;
+    },
+  });
+
+  const hooks = composeScopeHooks({
+    name: 'provider-beta',
+    createHolder: () => ({ scope: undefined }),
+    runScoped: async (_holder, fn) => {
+      const result = fn({ beta: 2 });
+      if (result instanceof Promise) await result;
+    },
+  });
+
+  const holder = hooks.createHolder();
+
+  await hooks.runScoped(holder, (params) => {
+    assert.deepStrictEqual(
+      params,
+      { alpha: 1, beta: 2 },
+      'Provider params are merged into callback context'
+    );
+  });
 });

--- a/test/unit/scope-hooks.test.ts
+++ b/test/unit/scope-hooks.test.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { GLOBAL } from '../../src/configs/poku.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { describe } from '../../src/modules/helpers/describe.js';
+import { afterEach } from '../../src/modules/helpers/each.ts';
 import { it, itBase } from '../../src/modules/helpers/it/core.js';
 
 const SCOPE_HOOKS_KEY = Symbol.for('@pokujs/poku.test-scope-hooks');
@@ -10,7 +11,7 @@ type ScopeHooks = {
   createHolder: () => { scope: unknown };
   runScoped: (
     holder: { scope: unknown },
-    fn: () => Promise<void> | void
+    fn: (params?: Record<string, unknown>) => Promise<void> | void
   ) => Promise<void>;
 };
 
@@ -22,91 +23,111 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 GLOBAL.configs.noExit = true;
 GLOBAL.configs.quiet = true;
 
+const g = globalThis as GlobalWithScopeHooks;
+const originalHooks = g[SCOPE_HOOKS_KEY];
+
+const overrideHooks = (hooks: ScopeHooks) => {
+  g[SCOPE_HOOKS_KEY] = hooks;
+};
+
 describe('itBase generic scope hooks', async () => {
-  const g = globalThis as GlobalWithScopeHooks;
-  const originalHooks = g[SCOPE_HOOKS_KEY];
+  afterEach(() => {
+    g[SCOPE_HOOKS_KEY] = originalHooks;
+  });
 
-  try {
-    await it('falls back to default execution when no hooks are registered', async () => {
-      delete g[SCOPE_HOOKS_KEY];
+  await it('falls back to default execution when no hooks are registered', async () => {
+    delete g[SCOPE_HOOKS_KEY];
 
-      let executed = false;
-      await itBase(() => {
-        executed = true;
-      });
-
-      assert.strictEqual(executed, true, 'itBase callback runs without hooks');
+    let executed = false;
+    await itBase(() => {
+      executed = true;
     });
 
-    await it('isolates scoped stores across concurrent itBase runs', async () => {
-      const als = new AsyncLocalStorage<{ id: number }>();
-      let idSeed = 0;
+    assert.strictEqual(executed, true, 'itBase callback runs without hooks');
+  });
 
-      const hooks: ScopeHooks = {
-        createHolder: () => ({ scope: undefined }),
-        runScoped: async (holder, fn) => {
-          const id = ++idSeed;
-          holder.scope = { id };
-          await als.run({ id }, async () => {
-            const result = fn();
-            if (result instanceof Promise) await result;
-          });
-        },
-      };
+  await it('isolates scoped stores across concurrent itBase runs', async () => {
+    const als = new AsyncLocalStorage<{ id: number }>();
+    let idSeed = 0;
 
-      g[SCOPE_HOOKS_KEY] = hooks;
-
-      const seenIds = new Map<string, number>();
-      let inFlight = 0;
-      let maxInFlight = 0;
-
-      const runCase = async (label: string) => {
-        await itBase(async () => {
-          const storeBefore = als.getStore();
-          if (!storeBefore) {
-            assert.fail(`${label}: store exists before await`);
-            return;
-          }
-
-          seenIds.set(label, storeBefore.id);
-
-          inFlight++;
-          if (inFlight > maxInFlight) maxInFlight = inFlight;
-
-          await sleep(40);
-
-          const storeAfter = als.getStore();
-          if (!storeAfter) {
-            assert.fail(`${label}: store exists after await`);
-            return;
-          }
-
-          assert.strictEqual(
-            storeAfter.id,
-            storeBefore.id,
-            `${label}: store id is stable through async hops`
-          );
-
-          inFlight--;
+    const hooks: ScopeHooks = {
+      createHolder: () => ({ scope: undefined }),
+      runScoped: async (holder, fn) => {
+        const id = ++idSeed;
+        holder.scope = { id };
+        await als.run({ id }, async () => {
+          const result = fn();
+          if (result instanceof Promise) await result;
         });
-      };
+      },
+    };
 
-      await Promise.all([runCase('A'), runCase('B')]);
+    overrideHooks(hooks);
 
-      const idA = seenIds.get('A');
-      const idB = seenIds.get('B');
+    const seenIds = new Map<string, number>();
+    let inFlight = 0;
+    let maxInFlight = 0;
 
-      assert.ok(typeof idA === 'number', 'A receives a scoped id');
-      assert.ok(typeof idB === 'number', 'B receives a scoped id');
-      assert.notStrictEqual(
-        idA,
-        idB,
-        'concurrent runs receive different stores'
+    const runCase = async (label: string) => {
+      await itBase(async () => {
+        const storeBefore = als.getStore();
+        if (!storeBefore) {
+          assert.fail(`${label}: store exists before await`);
+          return;
+        }
+
+        seenIds.set(label, storeBefore.id);
+
+        inFlight++;
+        if (inFlight > maxInFlight) maxInFlight = inFlight;
+
+        await sleep(40);
+
+        const storeAfter = als.getStore();
+        if (!storeAfter) {
+          assert.fail(`${label}: store exists after await`);
+          return;
+        }
+
+        assert.strictEqual(
+          storeAfter.id,
+          storeBefore.id,
+          `${label}: store id is stable through async hops`
+        );
+
+        inFlight--;
+      });
+    };
+
+    await Promise.all([runCase('A'), runCase('B')]);
+
+    const idA = seenIds.get('A');
+    const idB = seenIds.get('B');
+
+    assert.ok(typeof idA === 'number', 'A receives a scoped id');
+    assert.ok(typeof idB === 'number', 'B receives a scoped id');
+    assert.notStrictEqual(idA, idB, 'concurrent runs receive different stores');
+    assert.ok(maxInFlight >= 2, 'callbacks overlapped and ran concurrently');
+  });
+
+  await it('passes scope params into test callback', async () => {
+    const hooks: ScopeHooks = {
+      createHolder: () => ({ scope: undefined }),
+      runScoped: async (_holder, fn) => {
+        const result = fn({ value: 'from-scope-hooks' });
+        if (result instanceof Promise) await result;
+      },
+    };
+
+    overrideHooks(hooks);
+
+    await itBase((params) => {
+      const value = (params as { value: string }).value;
+      assert.strictEqual(
+        value,
+        'from-scope-hooks',
+        'context value is forwarded to callback'
       );
-      assert.ok(maxInFlight >= 2, 'callbacks overlapped and ran concurrently');
     });
-  } finally {
-    if (originalHooks) g[SCOPE_HOOKS_KEY] = originalHooks;
-    else delete g[SCOPE_HOOKS_KEY];
-  }
+  });
 });

--- a/website/docs/documentation/plugins/test-scope-hooks.mdx
+++ b/website/docs/documentation/plugins/test-scope-hooks.mdx
@@ -39,10 +39,12 @@ type ScopeHooks = {
   createHolder: () => { scope: unknown };
   runScoped: (
     holder: { scope: unknown },
-    fn: () => Promise<unknown> | unknown
+    fn: (params?: Record<string, unknown>) => Promise<unknown> | unknown
   ) => Promise<void>;
 };
 ```
+
+`runScoped` can forward params to the test callback by calling `fn({ ... })`.
 
 ## Registration API
 
@@ -55,9 +57,49 @@ composeScopeHooks({
   name: '@acme/my-plugin.scope-hooks',
   createHolder: () => ({ scope: undefined }),
   runScoped: async (holder, fn) => {
-    const result = fn();
+    const result = fn({ value: 'hello' });
     if (result instanceof Promise) await result;
   },
+});
+```
+
+## Typed Context (Full Type Safety)
+
+To get fully typed callback params in `it` / `test`, augment `ScopeHookContextMap` from `poku/plugins` in your plugin package.
+
+```ts
+// my-plugin.d.ts
+declare module 'poku/plugins' {
+  interface ScopeHookContextMap {
+    '@acme/my-plugin.scope-hooks': {
+      value: string;
+    };
+  }
+}
+```
+
+Then register your provider:
+
+```ts
+import { composeScopeHooks } from 'poku/plugins';
+
+composeScopeHooks({
+  name: '@acme/my-plugin.scope-hooks',
+  createHolder: () => ({ scope: undefined }),
+  runScoped: async (_holder, fn) => {
+    const result = fn({ value: 'hello' });
+    if (result instanceof Promise) await result;
+  },
+});
+```
+
+And test callbacks become typed automatically:
+
+```ts
+import { it, assert } from 'poku';
+
+it('has value', ({ value }) => {
+  assert.ok(value);
 });
 ```
 
@@ -94,7 +136,7 @@ type ScopeHooks = {
   createHolder: () => { scope: unknown };
   runScoped: (
     holder: { scope: unknown },
-    fn: () => Promise<unknown> | unknown
+    fn: (params?: Record<string, unknown>) => Promise<unknown> | unknown
   ) => Promise<void>;
 };
 
@@ -111,7 +153,7 @@ composeScopeHooks({
     holder.scope = { id };
 
     await als.run({ id }, async () => {
-      const result = fn();
+      const result = fn({ id });
       if (result instanceof Promise) await result;
     });
   },

--- a/website/docs/documentation/plugins/utilities.mdx
+++ b/website/docs/documentation/plugins/utilities.mdx
@@ -167,6 +167,9 @@ import type {
   ReporterEvents,
   InspectCLIResult,
   ScopeHookProvider,
+  ScopeHookContext,
+  ScopeHookContextMap,
+  ScopeHookParams,
   ScopeHooks,
 } from 'poku/plugins';
 ```

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/plugins/test-scope-hooks.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/plugins/test-scope-hooks.mdx
@@ -49,10 +49,12 @@ type ScopeHooks = {
   createHolder: () => { scope: unknown };
   runScoped: (
     holder: { scope: unknown },
-    fn: () => Promise<unknown> | unknown
+    fn: (params?: Record<string, unknown>) => Promise<unknown> | unknown
   ) => Promise<void>;
 };
 ```
+
+`runScoped` pode encaminhar params para o callback de teste chamando `fn({ ... })`.
 
 ## API de Registro
 
@@ -65,9 +67,49 @@ composeScopeHooks({
   name: '@acme/meu-plugin.scope-hooks',
   createHolder: () => ({ scope: undefined }),
   runScoped: async (holder, fn) => {
-    const result = fn();
+    const result = fn({ value: 'ola' });
     if (result instanceof Promise) await result;
   },
+});
+```
+
+## Contexto Tipado (Type Safety Completo)
+
+Para ter params totalmente tipados em callbacks de `it` / `test`, faca augment de `ScopeHookContextMap` de `poku/plugins` no pacote do plugin.
+
+```ts
+// meu-plugin.d.ts
+declare module 'poku/plugins' {
+  interface ScopeHookContextMap {
+    '@acme/meu-plugin.scope-hooks': {
+      value: string;
+    };
+  }
+}
+```
+
+Depois registre o provider:
+
+```ts
+import { composeScopeHooks } from 'poku/plugins';
+
+composeScopeHooks({
+  name: '@acme/meu-plugin.scope-hooks',
+  createHolder: () => ({ scope: undefined }),
+  runScoped: async (_holder, fn) => {
+    const result = fn({ value: 'ola' });
+    if (result instanceof Promise) await result;
+  },
+});
+```
+
+E os callbacks de teste ficam tipados automaticamente:
+
+```ts
+import { it, assert } from 'poku';
+
+it('tem value', ({ value }) => {
+  assert.ok(value);
 });
 ```
 
@@ -104,7 +146,7 @@ type ScopeHooks = {
   createHolder: () => { scope: unknown };
   runScoped: (
     holder: { scope: unknown },
-    fn: () => Promise<unknown> | unknown
+    fn: (params?: Record<string, unknown>) => Promise<unknown> | unknown
   ) => Promise<void>;
 };
 
@@ -121,7 +163,7 @@ composeScopeHooks({
     holder.scope = { id };
 
     await als.run({ id }, async () => {
-      const result = fn();
+      const result = fn({ id });
       if (result instanceof Promise) await result;
     });
   },


### PR DESCRIPTION
This PR enables plugins to inject parameters directly into test callbacks through scope hooks, making plugin-provided runtime context available in user tests with predictable behavior and strong validation coverage.

## What Changed

- Added scope-hook param propagation so composed plugin hooks can provide values consumed by `it`/`test` callbacks.
- Standardized composition behavior so multiple providers can contribute params deterministically.
- Simplified scope-hook typing to a practical params-object contract, reducing complexity while preserving type safety for the new flow.
- Updated plugin/scope-hook integration points so this works through the official plugin composition path.
- Added and adjusted tests to verify:
  - composition order and provider interaction
  - param forwarding into test callbacks
  - stable behavior under concurrent execution
  - real userland usage via fixture-based e2e tests executed through `poku()`.

## Why

- Unlocks a cleaner plugin author experience: plugins can expose per-test contextual data without ad-hoc globals or custom wiring.
- Keeps behavior explicit and predictable when multiple plugins participate.
- Improves confidence through both unit-level and end-to-end verification of the exact runtime path users rely on.

## Validation

- Unit tests cover scope-hook composition semantics and callback param injection.
- E2E fixtures prove that userland plugins can inject params through the public runtime API and that tests receive them as expected.

## Compatibility and Notes

- No breaking runtime model change for existing composed hooks; this extends hook output to include callback params.
- Typing was intentionally simplified for maintainability and clearer adoption by plugin authors.