### PR TITLE
fix: skip() with isolation:none no longer kills the entire process

### DIFF
--- a/src/modules/helpers/skip.ts
+++ b/src/modules/helpers/skip.ts
@@ -1,8 +1,14 @@
 import { exit } from 'node:process';
 import { GLOBAL } from '../../configs/poku.js';
 
+export class SkipFileSignal {
+  constructor(public readonly message: string) {}
+}
+
 export const skip = (message = 'Skipping'): never => {
   if (message) GLOBAL.reporter.onSkipFile({ message });
+
+  if (GLOBAL.configs.isolation === 'none') throw new SkipFileSignal(message);
 
   exit(0);
 };

--- a/src/services/run-test-in-process.ts
+++ b/src/services/run-test-in-process.ts
@@ -64,7 +64,7 @@ export const runTestInProcess = async (path: string): Promise<boolean> => {
     } else await testPromise;
   } catch (err) {
     if (err instanceof SkipFileSignal) {
-      // File was intentionally skipped — not a failure
+      // Intentionally skipped
     } else {
       if (timedOut)
         outputChunks.push(

--- a/src/services/run-test-in-process.ts
+++ b/src/services/run-test-in-process.ts
@@ -2,6 +2,7 @@ import { relative } from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 import { GLOBAL } from '../configs/poku.js';
+import { SkipFileSignal } from '../modules/helpers/skip.js';
 import { parserOutput } from '../parsers/output.js';
 import { afterEach, beforeEach } from './each.js';
 import { format } from './format.js';
@@ -61,13 +62,17 @@ export const runTestInProcess = async (path: string): Promise<boolean> => {
 
       await Promise.race([testPromise, timeoutPromise]);
     } else await testPromise;
-  } catch {
-    if (timedOut)
-      outputChunks.push(
-        `${format(`● Timeout: test file exceeded ${configs.timeout}ms limit`).fail().bold()}`
-      );
+  } catch (err) {
+    if (err instanceof SkipFileSignal) {
+      // File was intentionally skipped — not a failure
+    } else {
+      if (timedOut)
+        outputChunks.push(
+          `${format(`● Timeout: test file exceeded ${configs.timeout}ms limit`).fail().bold()}`
+        );
 
-    result = false;
+      result = false;
+    }
   } finally {
     if (process.exitCode !== 0) result = false;
 

--- a/test/__fixtures__/e2e/no-isolate/skip.test.ts
+++ b/test/__fixtures__/e2e/no-isolate/skip.test.ts
@@ -4,7 +4,6 @@ import { test } from '../../../../src/modules/helpers/test.js';
 
 skip('Skipping this file');
 
-// This line must never be reached
 test('should not run', () => {
   assert.strictEqual(true, false, 'This test must not execute');
 });

--- a/test/__fixtures__/e2e/no-isolate/skip.test.ts
+++ b/test/__fixtures__/e2e/no-isolate/skip.test.ts
@@ -1,5 +1,5 @@
-import { skip } from '../../../../src/modules/helpers/skip.js';
 import { assert } from '../../../../src/modules/essentials/assert.js';
+import { skip } from '../../../../src/modules/helpers/skip.js';
 import { test } from '../../../../src/modules/helpers/test.js';
 
 skip('Skipping this file');

--- a/test/__fixtures__/e2e/no-isolate/skip.test.ts
+++ b/test/__fixtures__/e2e/no-isolate/skip.test.ts
@@ -1,0 +1,10 @@
+import { skip } from '../../../../src/modules/helpers/skip.js';
+import { assert } from '../../../../src/modules/essentials/assert.js';
+import { test } from '../../../../src/modules/helpers/test.js';
+
+skip('Skipping this file');
+
+// This line must never be reached
+test('should not run', () => {
+  assert.strictEqual(true, false, 'This test must not execute');
+});

--- a/test/integration/no-isolate.test.ts
+++ b/test/integration/no-isolate.test.ts
@@ -89,6 +89,21 @@ describe('Service: runTestInProcess', async () => {
     assert.strictEqual(result, false, 'afterEach failure should fail');
   });
 
+  await it('skip does not stop the process', async () => {
+    resetState();
+    GLOBAL.configs = {
+      ...savedConfigs,
+      isolation: 'none',
+      quiet: true,
+    };
+
+    const skipped = await runTestInProcess(fixture('skip.test.ts'));
+    assert.strictEqual(skipped, true, 'Skipped file should not be treated as a failure');
+
+    const next = await runTestInProcess(fixture('pass.test.ts'));
+    assert.strictEqual(next, true, 'File after a skipped file should still run');
+  });
+
   resetState();
   GLOBAL.configs = savedConfigs;
 });

--- a/test/integration/no-isolate.test.ts
+++ b/test/integration/no-isolate.test.ts
@@ -98,10 +98,18 @@ describe('Service: runTestInProcess', async () => {
     };
 
     const skipped = await runTestInProcess(fixture('skip.test.ts'));
-    assert.strictEqual(skipped, true, 'Skipped file should not be treated as a failure');
+    assert.strictEqual(
+      skipped,
+      true,
+      'Skipped file should not be treated as a failure'
+    );
 
     const next = await runTestInProcess(fixture('pass.test.ts'));
-    assert.strictEqual(next, true, 'File after a skipped file should still run');
+    assert.strictEqual(
+      next,
+      true,
+      'File after a skipped file should still run'
+    );
   });
 
   resetState();


### PR DESCRIPTION
## Problem

When running with `isolation: 'none'`, all test files share a single Node.js process. Calling `skip()` inside any test file (especially at the top level) invokes `process.exit(0)`, which terminates the **shared process** — preventing all subsequent files from running at all.

### Reproduction

Given three test files run with `isolation: 'none'`:

```
tests/
  a.test.ts  ← calls skip() at top level
  b.test.ts
  c.test.ts
```

```bash
npx poku tests/ --isolation=none
# only a.test.ts output is shown — b and c never run
```

With the default `isolation: 'process'` the same setup works correctly because each file runs in its own child process, so `exit(0)` only kills that child.

## Root Cause

`skip()` unconditionally calls `process.exit(0)`:

```ts
export const skip = (message = 'Skipping'): never => {
  if (message) GLOBAL.reporter.onSkipFile({ message });
  exit(0); // ← kills the shared process in isolation:none
};
```

## Fix

- Introduce `SkipFileSignal` (exported from `skip.ts`) — a plain class used as a throw target
- `skip()` throws `SkipFileSignal` instead of calling `exit(0)` when `isolation === 'none'`
- `runTestInProcess` catches `SkipFileSignal` and treats it as a non-failure, letting the runner continue to the next file normally
- With the default `isolation: 'process'`, behaviour is **unchanged**

```ts
// skip.ts
export class SkipFileSignal {
  constructor(public readonly message: string) {}
}

export const skip = (message = 'Skipping'): never => {
  if (message) GLOBAL.reporter.onSkipFile({ message });
  if (GLOBAL.configs.isolation === 'none') throw new SkipFileSignal(message);
  exit(0);
};
```

```ts
// run-test-in-process.ts
} catch (err) {
  if (err instanceof SkipFileSignal) {
    // file was intentionally skipped — not a failure
  } else {
    // existing timeout + failure handling
    result = false;
  }
}
```

## Tests

- New fixture `test/__fixtures__/e2e/no-isolate/skip.test.ts` — a file that calls `skip()` at the top level with an assertion below that must never run
- New integration case in `test/integration/no-isolate.test.ts`:
  - asserts the skipped file returns `true` (not a failure)
  - asserts the file **after** the skipped file still executes normally