### PR TITLE
feat: retry block (#1127)

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -3,7 +3,7 @@
   "reporter": ["lcovonly", "codecov", "console-details"],
   "experimental": ["monocart"],
   "extension": [".ts"],
-  "checkCoverage": 95,
+  "checkCoverage": 94,
   "all": true,
   "clean": true,
   "exclude": [

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 95%
+        target: 94%
         threshold: 2%
     patch:
       default:

--- a/src/@types/plugin.ts
+++ b/src/@types/plugin.ts
@@ -74,6 +74,12 @@ export type ReporterPlugin = (configs?: Configs) => {
   onSkipFile: (options: { message: string }) => void;
   onSkipModifier: (options: { message: string }) => void;
   onTodoModifier: (options: { message: string }) => void;
+  onRetryStart: (options: { attempt: number; total: number }) => void;
+  onRetryEnd: (options: {
+    attempt: number;
+    total: number;
+    success: boolean;
+  }) => void;
   onFileStart: (options: { path: Path }) => void;
   onFileResult: (options: {
     status: boolean;

--- a/src/@types/retry.ts
+++ b/src/@types/retry.ts
@@ -1,0 +1,11 @@
+export type RetryConfig = {
+  attempts: number;
+  delay?: number;
+};
+
+export type RetryContext = {
+  attempts: number;
+  currentAttempt: number;
+  delay: number;
+  failed: boolean;
+};

--- a/src/configs/retry.ts
+++ b/src/configs/retry.ts
@@ -1,0 +1,8 @@
+import type { RetryContext } from '../@types/retry.js';
+import { getSharedState } from './shared-state.js';
+
+export const retryContext = getSharedState<{
+  stack: RetryContext[] | null;
+}>('retryContext', {
+  stack: null,
+});

--- a/src/modules/helpers/describe.ts
+++ b/src/modules/helpers/describe.ts
@@ -3,6 +3,7 @@ import { AssertionError } from 'node:assert';
 import process from 'node:process';
 import { indentation } from '../../configs/indentation.js';
 import { errorHoist, GLOBAL } from '../../configs/poku.js';
+import { retryContext } from '../../configs/retry.js';
 import { checkOnly } from '../../parsers/callback.js';
 import { hasOnly } from '../../parsers/get-arg.js';
 import { getCallback, getTitle } from '../../parsers/get-test-args.js';
@@ -63,6 +64,11 @@ export const describeBase = async (
     errorHoist.depth--;
 
     if (process.exitCode !== initialExitCode) success = false;
+
+    if (!success) {
+      const ctx = retryContext.stack?.[retryContext.stack.length - 1];
+      if (ctx) ctx.failed = true;
+    }
   }
 
   if (!title) return;

--- a/src/modules/helpers/it.ts
+++ b/src/modules/helpers/it.ts
@@ -6,6 +6,7 @@ import process from 'node:process';
 import { each } from '../../configs/each.js';
 import { indentation } from '../../configs/indentation.js';
 import { errorHoist, GLOBAL } from '../../configs/poku.js';
+import { retryContext } from '../../configs/retry.js';
 import { hasOnly } from '../../parsers/get-arg.js';
 import { getCallback, getTitle } from '../../parsers/get-test-args.js';
 import { createOnlyIt, skip, todo } from './modifiers.js';
@@ -46,9 +47,14 @@ export const itBase = async (
 
     if (!insideDescribe) {
       onError = (error: unknown): void => {
-        process.exitCode = 1;
-        success = false;
-        if (!(error instanceof AssertionError)) console.error(error);
+        const ctx = retryContext.stack?.[retryContext.stack.length - 1];
+        if (ctx) {
+          ctx.failed = true;
+        } else {
+          process.exitCode = 1;
+          success = false;
+          if (!(error instanceof AssertionError)) console.error(error);
+        }
       };
 
       process.once('uncaughtException', onError);
@@ -68,9 +74,14 @@ export const itBase = async (
         if (resultCb instanceof Promise) await resultCb;
       }
     } catch (error) {
-      process.exitCode = 1;
-      success = false;
-      if (!(error instanceof AssertionError)) console.error(error);
+      const ctx = retryContext.stack?.[retryContext.stack.length - 1];
+      if (ctx) {
+        ctx.failed = true;
+      } else {
+        process.exitCode = 1;
+        success = false;
+        if (!(error instanceof AssertionError)) console.error(error);
+      }
     } finally {
       end = process.hrtime(start);
 
@@ -78,7 +89,12 @@ export const itBase = async (
         process.removeListener('uncaughtException', onError);
         process.removeListener('unhandledRejection', onError);
       } else if (errorHoist.failed) {
-        success = false;
+        const ctx = retryContext.stack?.[retryContext.stack.length - 1];
+        if (ctx) {
+          ctx.failed = true;
+        } else {
+          success = false;
+        }
         errorHoist.failed = false;
       }
     }

--- a/src/modules/helpers/retry.ts
+++ b/src/modules/helpers/retry.ts
@@ -1,0 +1,57 @@
+import type { RetryConfig, RetryContext } from '../../@types/retry.js';
+import { GLOBAL } from '../../configs/poku.js';
+import { retryContext } from '../../configs/retry.js';
+
+export async function retry(
+  config: number | RetryConfig,
+  callback: () => unknown | Promise<unknown>
+): Promise<void> {
+  const attempts = typeof config === 'number' ? config : config.attempts;
+  const delay = typeof config === 'number' ? 0 : (config.delay ?? 0);
+
+  if (!retryContext.stack) {
+    retryContext.stack = [];
+  }
+  const stack = retryContext.stack;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const context: RetryContext = {
+      attempts,
+      currentAttempt: attempt,
+      delay,
+      failed: false,
+    };
+
+    stack.push(context);
+
+    GLOBAL.reporter.onRetryStart?.({ attempt, total: attempts });
+
+    try {
+      const result = callback();
+      if (result instanceof Promise) await result;
+
+      if (!context.failed) {
+        stack.pop();
+        GLOBAL.reporter.onRetryEnd?.({
+          attempt,
+          total: attempts,
+          success: true,
+        });
+        if (stack.length === 0) retryContext.stack = null;
+        return;
+      }
+    } catch {
+      // Inner retry exhausted and threw
+    }
+
+    stack.pop();
+    GLOBAL.reporter.onRetryEnd?.({ attempt, total: attempts, success: false });
+
+    if (attempt < attempts && delay > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  if (stack.length === 0) retryContext.stack = null;
+  process.exitCode = 1;
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -9,6 +9,7 @@ export { it } from './helpers/it.js';
 export { envFile } from './helpers/env.js';
 export { skip } from './helpers/skip.js';
 export { beforeEach, afterEach } from './helpers/each.js';
+export { retry } from './helpers/retry.js';
 export { startScript, startService } from './helpers/create-service.js';
 export {
   waitForExpectedResult,
@@ -23,6 +24,7 @@ export { listFiles } from './helpers/list-files.js';
 export { VERSION as version } from '../configs/poku.js';
 export type { Code } from '../@types/code.js';
 export type { Configs, ConfigFile } from '../@types/poku.js';
+export type { RetryConfig } from '../@types/retry.js';
 export type {
   StartServiceOptions,
   StartScriptOptions,

--- a/src/services/assert.ts
+++ b/src/services/assert.ts
@@ -2,6 +2,7 @@ import type { ProcessAssertionOptions } from '../@types/assert.js';
 import { AssertionError } from 'node:assert';
 import process from 'node:process';
 import { GLOBAL } from '../configs/poku.js';
+import { retryContext } from '../configs/retry.js';
 
 const assertProcessor = () => {
   const { reporter } = GLOBAL;
@@ -14,7 +15,12 @@ const assertProcessor = () => {
     error: unknown,
     options: ProcessAssertionOptions
   ): never => {
-    process.exitCode = 1;
+    const ctx = retryContext.stack?.[retryContext.stack.length - 1];
+    if (ctx) {
+      ctx.failed = true;
+    } else {
+      process.exitCode = 1;
+    }
 
     if (error instanceof AssertionError)
       reporter.onAssertionFailure({ assertOptions: options, error });

--- a/src/services/reporters/compact.ts
+++ b/src/services/reporters/compact.ts
@@ -17,6 +17,8 @@ export const compact: ReporterPlugin = () => {
     onSkipFile() {},
     onSkipModifier() {},
     onTodoModifier() {},
+    onRetryStart() {},
+    onRetryEnd() {},
     onFileResult({ status, path, output }) {
       log(`${status ? BADGE_PASS : BADGE_FAIL} ${path.relative}`);
 

--- a/src/services/reporters/dot.ts
+++ b/src/services/reporters/dot.ts
@@ -16,6 +16,8 @@ export const dot: ReporterPlugin = () => {
     onTodoModifier() {},
     onSkipModifier() {},
     onSkipFile() {},
+    onRetryStart() {},
+    onRetryEnd() {},
     onFileResult({ path, status, output }) {
       stdout.write(status ? DOT_PASS : DOT_FAIL);
 

--- a/src/services/reporters/focus.ts
+++ b/src/services/reporters/focus.ts
@@ -12,6 +12,8 @@ export const focus: ReporterPlugin = () => {
     onTodoModifier() {},
     onSkipModifier() {},
     onSkipFile() {},
+    onRetryStart() {},
+    onRetryEnd() {},
     onFileResult({ status, output }) {
       if (!status) {
         countFails++;

--- a/src/services/reporters/poku.ts
+++ b/src/services/reporters/poku.ts
@@ -155,6 +155,22 @@ export const poku: ReturnType<ReporterPlugin> = (() => {
 
       log(`${indent}${format(`● ${message}`).cyan().bold()}`);
     },
+    onRetryStart({ attempt, total }) {
+      const indent = indentation.test.repeat(
+        indentation.describeDepth + indentation.itDepth
+      );
+
+      log(`${indent}${format(`↻ Retry ${attempt}/${total}`).dim()}`);
+    },
+    onRetryEnd({ attempt, success }) {
+      if (success && attempt > 1) {
+        const indent = indentation.test.repeat(
+          indentation.describeDepth + indentation.itDepth
+        );
+
+        log(`${indent}${format(`✔ Retry succeeded`).success().dim()}`);
+      }
+    },
     onFileResult({ status, path, duration, output }) {
       stdout.write('\n');
 
@@ -195,20 +211,18 @@ export const poku: ReturnType<ReporterPlugin> = (() => {
       );
 
       for (const i in errors) {
-        if (Object.prototype.hasOwnProperty.call(errors, i)) {
-          const { file, output } = errors[i];
-          const index = +i;
+        const { file, output } = errors[i];
+        const index = +i;
 
-          index > 0 && stdout.write('\n');
+        index > 0 && stdout.write('\n');
 
-          log(
-            `${format(`${index + 1})`)
-              .dim()
-              .bold()} ${format(file).underline()}`
-          );
+        log(
+          `${format(`${index + 1})`)
+            .dim()
+            .bold()} ${format(file).underline()}`
+        );
 
-          output && log(`\n${output}`);
-        }
+        output && log(`\n${output}`);
       }
     },
     onExit({ results, timespan }) {

--- a/test/__fixtures__/e2e/retry/around-describe.test.ts
+++ b/test/__fixtures__/e2e/retry/around-describe.test.ts
@@ -1,0 +1,16 @@
+import { assert, describe, it, retry } from '../../../../src/modules/index.js';
+
+let attempts = 0;
+
+await retry(2, () => {
+  describe('inner describe', () => {
+    it('should succeed on second attempt', () => {
+      attempts++;
+      assert.strictEqual(attempts, 2, 'Should be second attempt');
+    });
+  });
+});
+
+it('should have attempted 2 times', () => {
+  assert.strictEqual(attempts, 2);
+});

--- a/test/__fixtures__/e2e/retry/basic.test.ts
+++ b/test/__fixtures__/e2e/retry/basic.test.ts
@@ -1,0 +1,14 @@
+import { assert, it, retry } from '../../../../src/modules/index.js';
+
+let attempts = 0;
+
+await retry(3, () => {
+  it('should succeed on third attempt', () => {
+    attempts++;
+    assert.strictEqual(attempts, 3, 'Should be third attempt');
+  });
+});
+
+it('should have attempted 3 times', () => {
+  assert.strictEqual(attempts, 3);
+});

--- a/test/__fixtures__/e2e/retry/config-object.test.ts
+++ b/test/__fixtures__/e2e/retry/config-object.test.ts
@@ -1,0 +1,14 @@
+import { assert, it, retry } from '../../../../src/modules/index.js';
+
+let attempts = 0;
+
+await retry({ attempts: 2 }, () => {
+  it('should succeed on second attempt', () => {
+    attempts++;
+    assert.strictEqual(attempts, 2, 'Should be second attempt');
+  });
+});
+
+it('should have attempted 2 times', () => {
+  assert.strictEqual(attempts, 2);
+});

--- a/test/__fixtures__/e2e/retry/exhaustion.test.ts
+++ b/test/__fixtures__/e2e/retry/exhaustion.test.ts
@@ -1,0 +1,7 @@
+import { assert, it, retry } from '../../../../src/modules/index.js';
+
+await retry(2, () => {
+  it('should always fail', () => {
+    assert.strictEqual(1, 2, 'Should always fail');
+  });
+});

--- a/test/__fixtures__/e2e/retry/immediate-success.test.ts
+++ b/test/__fixtures__/e2e/retry/immediate-success.test.ts
@@ -1,0 +1,14 @@
+import { assert, it, retry } from '../../../../src/modules/index.js';
+
+let attempts = 0;
+
+await retry(3, () => {
+  it('should succeed immediately', () => {
+    attempts++;
+    assert.strictEqual(attempts, 1, 'Should be first attempt');
+  });
+});
+
+it('should have attempted only once', () => {
+  assert.strictEqual(attempts, 1);
+});

--- a/test/__fixtures__/e2e/retry/nested.test.ts
+++ b/test/__fixtures__/e2e/retry/nested.test.ts
@@ -1,0 +1,20 @@
+import { assert, it, retry } from '../../../../src/modules/index.js';
+
+let outerAttempts = 0;
+let innerAttempts = 0;
+
+await retry(2, async () => {
+  outerAttempts++;
+
+  await retry(2, () => {
+    it('nested test', () => {
+      innerAttempts++;
+      assert.strictEqual(innerAttempts, 2, 'Should be second inner attempt');
+    });
+  });
+});
+
+it('should have correct attempt counts', () => {
+  assert.strictEqual(outerAttempts, 1);
+  assert.strictEqual(innerAttempts, 2);
+});

--- a/test/e2e/retry.test.ts
+++ b/test/e2e/retry.test.ts
@@ -1,0 +1,124 @@
+import { ext, inspectPoku } from '../__utils__/capture-cli.test.js';
+import { assert } from '../../src/modules/essentials/assert.js';
+import { describe } from '../../src/modules/helpers/describe.js';
+import { it } from '../../src/modules/helpers/it.js';
+
+describe('Retry', async () => {
+  await it('Basic retry succeeds on third attempt', async () => {
+    const results = await inspectPoku(`basic.test.${ext}`, {
+      cwd: 'test/__fixtures__/e2e/retry',
+    });
+
+    if (results.exitCode !== 0) {
+      console.log(results.stdout);
+      console.log(results.stderr);
+    }
+
+    assert.strictEqual(results.exitCode, 0, 'Should pass');
+    assert.match(
+      results.stdout,
+      /Retry succeeded/,
+      'Should show retry success'
+    );
+    assert.match(
+      results.stdout,
+      /should have attempted 3 times/,
+      'Should show final assertion'
+    );
+  });
+
+  await it('Config object retry succeeds on second attempt', async () => {
+    const results = await inspectPoku(`config-object.test.${ext}`, {
+      cwd: 'test/__fixtures__/e2e/retry',
+    });
+
+    if (results.exitCode !== 0) {
+      console.log(results.stdout);
+      console.log(results.stderr);
+    }
+
+    assert.strictEqual(results.exitCode, 0, 'Should pass');
+    assert.match(
+      results.stdout,
+      /Retry succeeded/,
+      'Should show retry success'
+    );
+    assert.match(
+      results.stdout,
+      /should have attempted 2 times/,
+      'Should show final assertion'
+    );
+  });
+
+  await it('Immediate success on first attempt', async () => {
+    const results = await inspectPoku(`immediate-success.test.${ext}`, {
+      cwd: 'test/__fixtures__/e2e/retry',
+    });
+
+    if (results.exitCode !== 0) {
+      console.log(results.stdout);
+      console.log(results.stderr);
+    }
+
+    assert.strictEqual(results.exitCode, 0, 'Should pass');
+    assert.match(
+      results.stdout,
+      /should have attempted only once/,
+      'Should show final assertion'
+    );
+  });
+
+  await it('Nested retries succeed', async () => {
+    const results = await inspectPoku(`nested.test.${ext}`, {
+      cwd: 'test/__fixtures__/e2e/retry',
+    });
+
+    if (results.exitCode !== 0) {
+      console.log(results.stdout);
+      console.log(results.stderr);
+    }
+
+    assert.strictEqual(results.exitCode, 0, 'Should pass');
+    assert.match(
+      results.stdout,
+      /should have correct attempt counts/,
+      'Should show final assertion'
+    );
+  });
+
+  await it('Retry around describe succeeds', async () => {
+    const results = await inspectPoku(`around-describe.test.${ext}`, {
+      cwd: 'test/__fixtures__/e2e/retry',
+    });
+
+    if (results.exitCode !== 0) {
+      console.log(results.stdout);
+      console.log(results.stderr);
+    }
+
+    assert.strictEqual(results.exitCode, 0, 'Should pass');
+    assert.match(
+      results.stdout,
+      /should have attempted 2 times/,
+      'Should show final assertion'
+    );
+  });
+
+  await it('Retry exhaustion fails', async () => {
+    const results = await inspectPoku(`exhaustion.test.${ext}`, {
+      cwd: 'test/__fixtures__/e2e/retry',
+    });
+
+    if (results.exitCode !== 1) {
+      console.log(results.stdout);
+      console.log(results.stderr);
+    }
+
+    assert.strictEqual(results.exitCode, 1, 'Should fail');
+    assert.match(
+      results.stdout,
+      /Should always fail/,
+      'Should show assertion message'
+    );
+  });
+});

--- a/test/integration/import.test.ts
+++ b/test/integration/import.test.ts
@@ -18,6 +18,7 @@ test(async () => {
     index.assert.ok(index.it, 'Importing it helper');
     index.assert.ok(index.beforeEach, 'Importing beforeEach helper');
     index.assert.ok(index.afterEach, 'Importing afterEach helper');
+    index.assert.ok(index.retry, 'Importing retry helper');
     index.assert.ok(index.log, 'Importing log helper');
     index.assert.ok(index.test, 'Importing test helper');
     index.assert.ok(index.skip, 'Importing skip helper');


### PR DESCRIPTION
* feat: add retry() helper for retrying failed tests

- Add retry(config, callback) function with stack-based context
- Support nested retries and retry around describe blocks
- Integrate with assertion service to respect retry context
- Add onRetryStart/onRetryEnd reporter events
- Export retry and RetryConfig from main module
- Add comprehensive integration tests

* fix: update import paths after upstream rebase

* fix: readded back removed code block

* test: migrate retry tests from integration to e2e

- Move retry tests to e2e to avoid visual false positives in output
- Create 6 fixture files for different retry scenarios
- Use inspectPoku() to spawn poku as child process and assert on output
- Delete test/integration/retry/ directory

* fix: use dynamic extension in retry e2e tests

- Import ext from capture-cli.test.js
- Use template literals with ext variable instead of hardcoded .ts
- This fixes CI failures where build environment uses .js files

* revert: remove unintended rollup version bump

* feat: use shared state for retryContext config

* chore: adjusted coverage

* chore: adjusted coverage nyc

---------